### PR TITLE
Add auth and movie APIs

### DIFF
--- a/04_Final-Project/package-lock.json
+++ b/04_Final-Project/package-lock.json
@@ -9,14 +9,18 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/bcrypt": "^5.0.2",
         "@types/express-fileupload": "^1.5.0",
+        "@types/jsonwebtoken": "^9.0.9",
         "@types/mongoose": "^5.11.97",
         "@types/uuid": "^10.0.0",
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-fileupload": "^1.5.1",
+        "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.8.0",
         "mongoose": "^8.5.3",
         "uuid": "^10.0.0"
@@ -610,6 +614,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -690,6 +703,16 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
+      "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -703,6 +726,12 @@
       "dependencies": {
         "mongoose": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.3.0",
@@ -1089,6 +1118,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1166,6 +1209,12 @@
       "engines": {
         "node": ">=16.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -1470,6 +1519,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2401,6 +2459,49 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -2446,11 +2547,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.0.0",
@@ -2721,6 +2864,26 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {
@@ -3138,7 +3301,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/04_Final-Project/package.json
+++ b/04_Final-Project/package.json
@@ -45,14 +45,18 @@
     }
   },
   "dependencies": {
+    "@types/bcrypt": "^5.0.2",
     "@types/express-fileupload": "^1.5.0",
+    "@types/jsonwebtoken": "^9.0.9",
     "@types/mongoose": "^5.11.97",
     "@types/uuid": "^10.0.0",
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-fileupload": "^1.5.1",
+    "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.8.0",
     "mongoose": "^8.5.3",
     "uuid": "^10.0.0"

--- a/04_Final-Project/src/controllers/movieController.ts
+++ b/04_Final-Project/src/controllers/movieController.ts
@@ -1,39 +1,49 @@
-import { channel } from 'diagnostics_channel';
-import {Request, Response, NextFunction} from 'express';
+import { UploadedFile } from "express-fileupload";
+import { Request, Response } from 'express';
 import IMovie from '../interfaces/movieInterface.js';
 import movieService from '../services/movieService.js';
 
 class MovieController {
-    async getAll(req: Request, res: Response, next: NextFunction) {}
-    async getOne(req: Request, res: Response, next: NextFunction) {}
-    async create(req: Request, res: Response, next: NextFunction) {
-        try {
-            const {title, releaseDate, trailerLink, posterUrl, genres} = req.body;
-            const poster = req.files?.poster;
+  async getAll(req: Request, res: Response) {
+    const movies = await movieService.getAll();
+    res.json(movies);
+  }
 
-            const movieData = {
-                title,
-                releaseDate, 
-                trailerLink,
-                posterUrl,
-                genres
-            }as IMovie;
+  async getOne(req: Request, res: Response) {
+    const movie = await movieService.getOne(req.params.id);
+    if (!movie) return res.status(404).json({ error: 'Not found' });
+    res.json(movie);
+  }
 
+  async search(req: Request, res: Response) {
+    const movies = await movieService.search(req.query as Record<string, string>);
+    res.json(movies);
+  }
 
-            const createdMovie = await movieService.create(movieData, poster);
-
-            res.status(201).json(createdMovie);
-
-        }catch (err) {
-            console.log(err);
-            res.status(500).json(err)
-        }
+  async create(req: Request, res: Response) {
+    try {
+      const poster = req.files?.poster as UploadedFile;
+      const createdMovie = await movieService.create(req.body as IMovie, poster);
+      res.status(201).json(createdMovie);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
     }
-    async update(req: Request, res: Response, next: NextFunction) {}
-    async delete(req: Request, res: Response, next: NextFunction) {}
+  }
+
+  async update(req: Request, res: Response) {
+    try {
+      const poster = req.files?.poster as UploadedFile;
+      const updated = await movieService.update(req.params.id, req.body, poster);
+      res.json(updated);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  }
+
+  async delete(req: Request, res: Response) {
+    const deleted = await movieService.delete(req.params.id);
+    res.json(deleted);
+  }
 }
 
-
-
 export default new MovieController();
-

--- a/04_Final-Project/src/controllers/userController.ts
+++ b/04_Final-Project/src/controllers/userController.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express';
+import { UploadedFile } from 'express-fileupload';
+import userService from '../services/userService.js';
+import IUser from '../interfaces/userInterface.js';
+
+class UserController {
+  async register(req: Request, res: Response) {
+    try {
+      const avatar = req.files?.avatar as UploadedFile | undefined;
+      const userData = req.body as IUser;
+      const created = await userService.register(userData, avatar);
+      res.status(201).json(created);
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  }
+
+  async login(req: Request, res: Response) {
+    try {
+      const { email, password } = req.body;
+      const result = await userService.login(email, password);
+      if (!result) return res.status(404).json({ error: 'Invalid credentials' });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  }
+
+  async getAll(req: Request, res: Response) {
+    const users = await userService.getAll();
+    res.json(users);
+  }
+
+  async update(req: Request, res: Response) {
+    const updated = await userService.update(req.params.id, req.body);
+    res.json(updated);
+  }
+
+  async delete(req: Request, res: Response) {
+    const deleted = await userService.delete(req.params.id);
+    res.json(deleted);
+  }
+}
+
+export default new UserController();

--- a/04_Final-Project/src/interfaces/userInterface.ts
+++ b/04_Final-Project/src/interfaces/userInterface.ts
@@ -1,0 +1,10 @@
+import { Document } from 'mongoose';
+
+export default interface IUser extends Document {
+  name: string;
+  email: string;
+  password: string;
+  role: string;
+  isActive: boolean;
+  avatar?: string;
+}

--- a/04_Final-Project/src/main.ts
+++ b/04_Final-Project/src/main.ts
@@ -1,37 +1,29 @@
-
-
 import express from 'express';
-
 import dotenv from 'dotenv';
-
 import mongoose from 'mongoose';
 import movieRouter from './routers/movieRouter.js';
+import userRouter from './routers/userRouter.js';
 import cors from 'cors';
 import fileUpload from 'express-fileupload';
-
 
 dotenv.config();
 
 const PORT = process.env.PORT || 7989;
-console.log(PORT);
 const app = express();
 
 app.use(fileUpload());
 app.use(express.static('static'));
-
-app.use(cors({
-   origin: '*'
-}))
-
+app.use(cors({ origin: '*' }));
 app.use(express.json());
-app.use('/api', movieRouter)
+
+app.use('/api', movieRouter);
+app.use('/auth', userRouter);
 
 const startApp = async () => {
   try {
-
     mongoose.set('strictQuery', true);
     await mongoose.connect(String(process.env.MONGO_URI));
-    console.log("Succssefully connected to DB");
+    console.log('Succssefully connected to DB');
 
     app.listen(PORT, () => {
       if (process.env.NODE_ENV === 'prod') {

--- a/04_Final-Project/src/middlewares/authMiddleware.ts
+++ b/04_Final-Project/src/middlewares/authMiddleware.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+interface AuthRequest extends Request {
+  user?: unknown;
+}
+
+export function authenticate(req: AuthRequest, res: Response, next: NextFunction) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const decoded = jwt.verify(token, process.env.SECRET_KEY || '');
+    req.user = decoded;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+export function checkRole(roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const user = req.user as { role?: string } | undefined;
+    if (!user || !roles.includes(user?.role || "")) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/04_Final-Project/src/models/userModel.ts
+++ b/04_Final-Project/src/models/userModel.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+import IUser from '../interfaces/userInterface.js';
+
+const UserSchema = new mongoose.Schema<IUser>(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    avatar: { type: String, default: 'default.jpg' },
+    role: { type: String, default: 'User' },
+    isActive: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IUser>('User', UserSchema);

--- a/04_Final-Project/src/routers/movieRouter.ts
+++ b/04_Final-Project/src/routers/movieRouter.ts
@@ -1,13 +1,14 @@
-import {Router} from 'express';
+import { Router } from 'express';
 import MovieController from '../controllers/movieController.js';
+import { authenticate, checkRole } from '../middlewares/authMiddleware.js';
 
 const router: Router = Router();
 
-router.get('/movies', MovieController.getAll);
-router.get('/movies/:id', MovieController.getOne);
-router.post('/movies/', MovieController.create);
-router.put('/movies/:id', MovieController.update);
-router.delete('/movies/:id', MovieController.delete);
+router.get('/movies', authenticate, MovieController.getAll);
+router.get('/movies/search', authenticate, MovieController.search);
+router.get('/movies/:id', authenticate, MovieController.getOne);
+router.post('/movies', authenticate, checkRole(['Admin']), MovieController.create);
+router.put('/movies/:id', authenticate, checkRole(['Admin']), MovieController.update);
+router.delete('/movies/:id', authenticate, checkRole(['Admin']), MovieController.delete);
 
 export default router;
-

--- a/04_Final-Project/src/routers/userRouter.ts
+++ b/04_Final-Project/src/routers/userRouter.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import UserController from '../controllers/userController.js';
+import { checkRole, authenticate } from '../middlewares/authMiddleware.js';
+
+const router = Router();
+
+router.post('/register', UserController.register);
+router.post('/login', UserController.login);
+router.get('/users', authenticate, checkRole(['Admin']), UserController.getAll);
+router.put('/users/:id', authenticate, checkRole(['Admin']), UserController.update);
+router.delete('/users/:id', authenticate, checkRole(['Admin']), UserController.delete);
+
+export default router;

--- a/04_Final-Project/src/services/userService.ts
+++ b/04_Final-Project/src/services/userService.ts
@@ -1,0 +1,52 @@
+import IUser from '../interfaces/userInterface.js';
+import UserModel from '../models/userModel.js';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import fileService from '../utils/fileService.js';
+import { UploadedFile } from 'express-fileupload';
+
+dotenv.config();
+
+class UserService {
+  async register(userData: IUser, avatar?: UploadedFile) {
+    const existing = await UserModel.findOne({ email: userData.email });
+    if (existing) {
+      throw new Error('User already exists');
+    }
+    if (avatar) {
+      const avatarName = fileService.save(avatar);
+      userData.avatar = avatarName;
+    }
+    userData.password = await bcrypt.hash(userData.password, 10);
+    const created = await UserModel.create(userData);
+    return created;
+  }
+
+  async login(email: string, password: string) {
+    const user = await UserModel.findOne({ email });
+    if (!user) return null;
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return null;
+    if (!process.env.SECRET_KEY) throw new Error('Missing secret');
+    const token = jwt.sign(
+      { id: user.id, email: user.email, role: user.role },
+      process.env.SECRET_KEY
+    );
+    return { user, accessToken: token };
+  }
+
+  async getAll() {
+    return UserModel.find();
+  }
+
+  async update(id: string, data: Partial<IUser>) {
+    return UserModel.findByIdAndUpdate(id, data, { new: true });
+  }
+
+  async delete(id: string) {
+    return UserModel.findByIdAndDelete(id);
+  }
+}
+
+export default new UserService();

--- a/04_Final-Project/src/utils/fileService.ts
+++ b/04_Final-Project/src/utils/fileService.ts
@@ -1,19 +1,20 @@
 import path from 'path';
 import fs from 'fs';
 import { v4 as uuidv4 } from 'uuid';
+import { UploadedFile } from 'express-fileupload';
+
 class FileService {
-    save(file: any): string {
-        const fileExtension = file.mimetype.split("/")[1]; // jpeg
-        const fileName = uuidv4() + "." + fileExtension; // asdfsdrgerrtg.jpeg
-        const filePath = path.resolve("static", fileName);
-        file.mv(filePath);
-        return fileName;
-    }
-    delete(fileName: string): void {
-        const filePath = path.resolve('static', fileName);
-        fs.unlinkSync(filePath);
+  save(file: UploadedFile): string {
+    const fileExtension = file.mimetype.split('/')[1];
+    const fileName = uuidv4() + '.' + fileExtension;
+    const filePath = path.resolve('static', fileName);
+    file.mv(filePath);
+    return fileName;
+  }
 
-
-    }
+  delete(fileName: string): void {
+    const filePath = path.resolve('static', fileName);
+    fs.unlinkSync(filePath);
+  }
 }
 export default new FileService();


### PR DESCRIPTION
## Summary
- add user model, service, controller, and router
- add auth middleware with role checks
- implement movie service/controller with search
- secure movie routes and include new user routes
- update file upload utilities and main server file

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68400613761483208857e2e746b8c599